### PR TITLE
fix: DexPaprika entry claims ~1s updates and no rate limits; measured 8 frames in 60s

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The list includes both free APIs, and those which you have to pay to use - 💰
  - [Blockchain transactions](https://www.blockchain.com/api/api_websocket) - Provides real-time notifications about new transactions and blocks.
  - [Open Rail Data](https://wiki.openraildata.com/index.php/Rail_Data_FAQ) - A collection of APIs that provide data relating to the UK rail network, including reference data, train timetables, and live service updates. The live data is streamed using the STOMP protocol.
  - [CoinCap](https://docs.coincap.io/) - provides real-time pricing and market activity for over 1,000 cryptocurrencies.
- - [DexPaprika](https://api.dexpaprika.com) - Free real-time DEX data across 36 blockchains via SSE streaming. 36M+ pools, 33M+ tokens, swap-driven price updates. No API key needed; free tier is 200K requests/month. [Streaming docs](https://docs.dexpaprika.com/streaming/introduction).
+ - [DexPaprika](https://api.dexpaprika.com) - DEX data for 36 blockchains via SSE streaming, pushed as swaps land. 36M+ pools, 33M+ tokens. Free tier, no API key required ([plans and limits](https://dexpaprika.com/api/pricing)). [Streaming docs](https://docs.dexpaprika.com/streaming/introduction).
  - [Finnhub Stock API](https://finnhub.io/) - Real-Time RESTful APIs and Websocket for Stocks, Currencies, and Crypto.
  - [CoinCheck](https://coincheck.com/documents/exchange/api#websocket) - a cryptocurrency API that has a WebSocket interface (in beta)
  - 💰 [Twitter](https://developer.twitter.com/en/docs/tutorials/consuming-streaming-data.html) - Twitter provides a streaming interface for Enterprise clients 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The list includes both free APIs, and those which you have to pay to use - 💰
  - [Blockchain transactions](https://www.blockchain.com/api/api_websocket) - Provides real-time notifications about new transactions and blocks.
  - [Open Rail Data](https://wiki.openraildata.com/index.php/Rail_Data_FAQ) - A collection of APIs that provide data relating to the UK rail network, including reference data, train timetables, and live service updates. The live data is streamed using the STOMP protocol.
  - [CoinCap](https://docs.coincap.io/) - provides real-time pricing and market activity for over 1,000 cryptocurrencies.
- - [DexPaprika](https://api.dexpaprika.com) - Free real-time DEX data across 34 blockchains via SSE streaming. 30M+ pools, 27M+ tokens, ~1 second price updates. No API key, no rate limits. [Streaming docs](https://docs.dexpaprika.com/streaming/introduction).
+ - [DexPaprika](https://api.dexpaprika.com) - Free real-time DEX data across 36 blockchains via SSE streaming. 36M+ pools, 33M+ tokens, swap-driven price updates. No API key needed; free tier is 200K requests/month. [Streaming docs](https://docs.dexpaprika.com/streaming/introduction).
  - [Finnhub Stock API](https://finnhub.io/) - Real-Time RESTful APIs and Websocket for Stocks, Currencies, and Crypto.
  - [CoinCheck](https://coincheck.com/documents/exchange/api#websocket) - a cryptocurrency API that has a WebSocket interface (in beta)
  - 💰 [Twitter](https://developer.twitter.com/en/docs/tutorials/consuming-streaming-data.html) - Twitter provides a streaming interface for Enterprise clients 


### PR DESCRIPTION
One line, from my own PR #7. I work on DexPaprika, so this is a self-correction.

This list is about streaming, so the cadence claim is the one that matters. The entry says **"~1 second price updates"**. It does not behave that way. Frames follow trade activity, not a one second tick, and free tier data carries a documented delay of up to 15 seconds. I sampled WETH on Ethereum again today, about as busy as an ERC-20 gets, for 60 seconds:

```
$ curl -sN "https://streaming.dexpaprika.com/sse/prices?method=token_price&chain=ethereum&address=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
5 token_price frames in 60s
gaps: 13s, 11s, 13s, 12s
```

An earlier sample got 8 frames in the same window. Either way it is nowhere near one second, and a quiet token on a quiet chain goes longer still. The entry now says frames are pushed as swaps land and promises no interval.

**"no rate limits" is also wrong.** The free tier is metered, a monthly request allowance plus 30 requests per minute, and each stream update counts as one request. The entry links https://dexpaprika.com/api/pricing instead of naming a figure, because the allowance changed on 11 August. No API key needed to start is true and stays.

**The coverage numbers are a release behind.** The entry claims "34 blockchains", "30M+ pools" and "27M+ tokens". Live:

```
$ curl -s https://api.dexpaprika.com/stats
{"chains":36,"factories":235,"pools":38564883,"tokens":35483652}
```

I used the rounded published figures (36 chains, 36M+ pools, 33M+ tokens) rather than exact live values, so the line does not go stale again in a month.